### PR TITLE
添加及时剔除机制，而不是仅依靠心跳维持剔除

### DIFF
--- a/ring.go
+++ b/ring.go
@@ -16,11 +16,6 @@ import (
 	"gopkg.in/freshcn/redis.v5/internal/pool"
 )
 
-type AddrWeight struct {
-	Addr   string
-	Weight uint8
-}
-
 const nreplicas = 100
 
 var errRingShardsDown = errors.New("redis: all ring shards are down")

--- a/ring.go
+++ b/ring.go
@@ -390,7 +390,7 @@ func (c *Ring) Process(cmd Cmder) (e error) {
 	var err error
 
 	// 轮询模式
-	for i := 0; i < 8*threshold; i++ {
+	for i := 0; i < 16*threshold; i++ {
 		if c.opt.PollMode {
 			shard, err = c.nextShard()
 		} else {

--- a/ring.go
+++ b/ring.go
@@ -16,7 +16,7 @@ import (
 	"gopkg.in/freshcn/redis.v5/internal/pool"
 )
 
-const threshold = 2
+const threshold = 3
 const nreplicas = 100
 
 var errRingShardsDown = errors.New("redis: all ring shards are down")


### PR DESCRIPTION
1. 添加及时剔除机制，而不是仅依靠心跳维持
2.现单一节点故障不会造成持续报错了，而是寻找可用节点